### PR TITLE
Adds S3 and DynamoDB resource dependencies to **backend** manifest.

### DIFF
--- a/backend/resources/ddb.yml
+++ b/backend/resources/ddb.yml
@@ -1,0 +1,77 @@
+---
+Resources:
+  TestsTable:
+    Type: AWS::DynamoDB::Table
+    Description: Catalog of tests
+    Properties:
+      TableName: ${self:custom.appshortname}-tests-table
+      AttributeDefinitions:
+        - AttributeName: TestId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: PlayerId
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
+
+  RunsTable:
+    Type: AWS::DynamoDB::Table
+    Description: Catalog of test runs
+    Properties:
+      TableName: ${self:custom.appshortname}-testruns-table
+      AttributeDefinitions:
+        - AttributeName: TestRunId
+          AttributeType: S
+        - AttributeName: Timestamp
+          AttributeType: S
+        - AttributeName: TestId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: TestRunId
+          KeyType: HASH
+        - AttributeName: Timestamp
+          KeyType: RANGE
+
+      LocalSecondaryIndexes:
+        - IndexName: SortedByGameId
+          KeySchema:
+            - AttributeName: TestRunId
+              KeyType: HASH
+            - AttributeName: TestId
+              KeyType: RANGE
+          Projection:
+            ProjectionType: KEYS_ONLY
+
+      ProvisionedThroughput:
+        ReadCapacityUnits: 2
+        WriteCapacityUnits: 2
+
+  ResultsTable:
+    Type: AWS::DynamoDB::Table
+    Description: Results storage
+    Properties:
+      TableName: ${self:custom.appshortname}-results-table
+      AttributeDefinitions:
+        - AttributeName: ResultsId
+          AttributeType: S
+        - AttributeName: TestRunId
+          AttributeType: S
+        - AttributeName: StartTimestamp
+          AttributeType: S
+        - AttributeName: EndTimestamp
+          AttributeType: S
+        - AttributeName: Region
+          AttributeType: S
+        - AttributeName: StatusCode
+          AttributeType: S
+      KeySchema:
+        - AttributeName: ResultsId
+          KeyType: HASH
+        - AttributeName: TestRunId
+          KeyType: RANGE
+
+      ProvisionedThroughput:
+        ReadCapacityUnits: 5
+        WriteCapacityUnits: 5
+

--- a/backend/resources/s3.yml
+++ b/backend/resources/s3.yml
@@ -1,0 +1,13 @@
+---
+Resources:
+  DeploymentBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: ${self:custom.appshortname}-${self:provider.stage}-pewpewpew
+      AccessControl: PublicRead
+
+Outputs:
+  DeploymentBucketName:
+    Description: The name of the stackset deployment bucket.
+    Value:
+      Ref: DeploymentBucket

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -28,12 +28,6 @@ custom:
 
 package:
   individually: true
-#  include:
-#    - include-me.py
-#    - include-me-dir/**
-#  exclude:
-#    - exclude-me.py
-#    - exclude-me-dir/**
 
 functions:
   ping:
@@ -44,16 +38,8 @@ functions:
           method: GET
           cors: true
 
-#resources:
-#  Resources:
-#    NewResource:
-#      Type: AWS::S3::Bucket
-#      Properties:
-#        BucketName: my-new-bucket
-#  Outputs:
-#     NewOutput:
-#       Description: "Description for the output"
-#       Value: "Some output value"
+resources:
+  - ${file(resources/ddb.yml)}
 
 plugins:
   - serverless-python-requirements

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -26,6 +26,16 @@ custom:
   appname: pewpewpew-array
   appshortname: pppa-${self:provider.stage}
 
+  DDB_TESTS:
+    Ref: TestsTable
+  DDB_TESTRUNS:
+    Ref: RunsTable
+  DDB_RESULTS:
+    Ref: ResultsTable
+
+  S3_DEPLOYMENT_BUCKET:
+    Ref: DeploymentBucket
+
 package:
   individually: true
 
@@ -40,6 +50,7 @@ functions:
 
 resources:
   - ${file(resources/ddb.yml)}
+  - ${file(resources/s3.yml)}
 
 plugins:
   - serverless-python-requirements

--- a/backend/utils/env.js
+++ b/backend/utils/env.js
@@ -1,0 +1,1 @@
+exports.TARGET_REGION = process.env.TARGET_REGION || 'ap-northeast-1'

--- a/backend/utils/env.js
+++ b/backend/utils/env.js
@@ -1,1 +1,0 @@
-exports.TARGET_REGION = process.env.TARGET_REGION || 'ap-northeast-1'


### PR DESCRIPTION
Adds the following resources (and the corresponding `env` vars):

- DynamoDB
  - `TestsTable`
  - `RunsTable`
  - `ResultsTable`

- S3
  - `DeploymentBucket`
